### PR TITLE
ci: fix cargo test on nightly compiler

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,8 +112,8 @@ mod tests {
             ),
         ];
 
-        for (case, expected) in cases {
-            assert_eq!(normalize_string(case), expected)
+        for (case, expected) in &cases {
+            assert_eq!(normalize_string(case), *expected)
         }
     }
 
@@ -128,14 +128,14 @@ mod tests {
             ),
         ];
 
-        for (case, expected) in cases {
+        for (case, expected) in &cases {
             let got = WIKILINK_REGEX
                 .captures(case)
                 .unwrap()
                 .name("link")
                 .unwrap()
                 .as_str();
-            assert_eq!(got.trim(), expected);
+            assert_eq!(got.trim(), *expected);
         }
     }
 
@@ -147,14 +147,14 @@ mod tests {
             ("[[🪴 Sowing<Your>Garden | 🪴/Emoji/Link]]", "🪴/Emoji/Link"),
         ];
 
-        for (case, expected) in cases {
+        for (case, expected) in &cases {
             let got = WIKILINK_REGEX
                 .captures(case)
                 .unwrap()
                 .name("title")
                 .unwrap()
                 .as_str();
-            assert_eq!(got.trim(), expected)
+            assert_eq!(got.trim(), *expected)
         }
     }
 }


### PR DESCRIPTION
```
error[E0277]: `[(&str, &str); 2]` is not an iterator
   --> src/lib.rs:115:33
    |
115 |         for (case, expected) in cases {
    |                                 ^^^^^ borrow the array with `&` or call `.iter()` on it to iterate over it
    |
    = help: the trait `Iterator` is not implemented for `[(&str, &str); 2]`
    = note: arrays are not iterators, but slices like the following are: `&[1, 2, 3]`
    = note: required because of the requirements on the impl of `IntoIterator` for `[(&str, &str); 2]`
    = note: required by `into_iter`
```